### PR TITLE
Fix dashboard summary to display separate book and market totals

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -346,8 +346,12 @@ function Dashboard() {
             <span className="metric-value">{totalAssets}件</span>
           </div>
           <div className="metric">
+            <span>簿価総額:</span>
+            <span className="metric-value">{formatCurrency(classSummary?.items ? classSummary.items.reduce((sum, item) => sum + item.book_total_jpy, 0) : totalValue)}</span>
+          </div>
+          <div className="metric">
             <span>総評価額:</span>
-            <span className="metric-value">{formatCurrency(totalValue)}</span>
+            <span className="metric-value">{formatCurrency(classSummary?.items ? classSummary.items.reduce((sum, item) => sum + item.market_total_jpy, 0) : totalValue)}</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add separate 簿価総額 (book value total) row in dashboard summary
- Calculate both totals from class summary API data instead of using old totalValue  
- Ensures accurate display of book value vs market value totals

## Test plan
- [x] Verify dashboard shows different values for 簿価総額 and 総評価額
- [x] Confirm calculations use class summary data properly
- [x] Test fallback to totalValue when class summary unavailable

🤖 Generated with [Claude Code](https://claude.ai/code)