### PR TITLE
エクスポート機能修正: データベース全体ダウンロード不具合解決

### DIFF
--- a/server.js
+++ b/server.js
@@ -1922,7 +1922,7 @@ app.get('/api/export/full-database', requireAuth, (req, res) => {
       // Current market value
       'current_value_jpy', 'valuation_date', 'fx_context',
       // US stock details
-      'ticker', 'exchange', 'us_quantity', 'avg_price_usd',
+      'ticker', 'exchange', 'us_quantity', 'avg_price_usd', 'market_price_usd',
       // JP stock details
       'code', 'jp_quantity', 'avg_price_jpy',
       // Precious metal details


### PR DESCRIPTION
## Summary
データベース全体エクスポート機能が失敗する不具合を修正

## 問題
「データベース全体をダウンロード」機能でエクスポートに失敗していた。

### 原因
- SQLクエリで`market_price_usd`フィールドを取得
- CSVヘッダーリストに`market_price_usd`が含まれていない
- データとヘッダーの不整合によりCSV書き込み処理が失敗

## 修正内容

### 技術的修正
```javascript
// server.js:1925 CSVヘッダー定義を修正
// 修正前
'ticker', 'exchange', 'us_quantity', 'avg_price_usd',

// 修正後  
'ticker', 'exchange', 'us_quantity', 'avg_price_usd', 'market_price_usd',
```

### 修正効果
✅ **SQLクエリとCSVヘッダーの完全整合**  
✅ **US株の時価データも正しくエクスポート**  
✅ **データベース全体のダウンロード機能が復旧**  

## 対象機能
- `/api/export/full-database` エンドポイント
- フロントエンド「インポート・エクスポート」ページ
- 「データベース全体をダウンロード」ボタン

## 検証結果

### テスト済み項目
- [x] SQLクエリが正常実行される
- [x] 全フィールドがCSVヘッダーと一致する
- [x] CSVファイルが正常生成される
- [x] US株の`market_price_usd`データが含まれる
- [x] エクスポート処理がエラーなく完了する

### サンプル出力
```csv
id,class,name,ticker,exchange,us_quantity,avg_price_usd,market_price_usd,...
88,us_stock,ファイザー,PFE,,1.0,24.26,25.11,...
```

## Test plan
- [x] データベース全体エクスポート機能をテスト
- [x] 複数資産クラス（US株、日本株、貴金属等）でエクスポート確認
- [x] CSVファイルの整合性検証
- [x] フロントエンドからのダウンロード動作確認

## 関連
この修正は先行する以下のPRと関連：
- #25 US株損益計算修正（市場価格データ追加による影響）

🤖 Generated with [Claude Code](https://claude.ai/code)