### PR TITLE
fix: add 'market' as valid valuation_source for CSV import

### DIFF
--- a/server/csv/normalize.js
+++ b/server/csv/normalize.js
@@ -45,7 +45,7 @@ function validateRow(row) {
   }
   
   // Valuation source validation
-  const validValuationSources = ['manual', 'market_api', 'formula'];
+  const validValuationSources = ['manual', 'market_api', 'market', 'formula'];
   if (row.valuation_source && !validValuationSources.includes(row.valuation_source)) {
     throw new Error(`valuation_source must be one of: ${validValuationSources.join(', ')}`);
   }


### PR DESCRIPTION
## Summary
- Fixed CSV import error when importing from Ubuntu server to Windows server
- Added 'market' as a valid valuation_source option in CSV validation

## Problem
Ubuntu server exports CSV files with `valuation_source='market'`, but Windows server validation only accepted `['manual', 'market_api', 'formula']`, causing import failures with error: "valuation_source must be one of: manual, market_api, formula"

## Solution
Updated `server/csv/normalize.js` to include 'market' in the valid valuation sources list.

## Test plan
- [x] Export CSV from Ubuntu server containing 'market' valuation_source values
- [x] Import CSV to Windows server should now succeed without validation errors
- [x] Existing validation for other valuation_source values remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)